### PR TITLE
Fix: chowcho.run should not chose a closed window

### DIFF
--- a/lua/chowcho/init.lua
+++ b/lua/chowcho/init.lua
@@ -3,7 +3,6 @@ local ui = require('chowcho.ui')
 local chowcho = {}
 
 local _float_wins = {}
-local _wins = {}
 
 -- for default options
 local _opt = {
@@ -96,6 +95,7 @@ chowcho.run = function(fn, opt)
 
   set_highlight(opt_local)
 
+  local _wins = {}
   for i, v in ipairs(wins) do
     local pos = calc_center_win_pos(v)
     local buf = vim.api.nvim_win_get_buf(v)


### PR DESCRIPTION
`chowcho.run` look up all windows, select some, and record the selected ones to `_wins` table.
The problem is that `_wins` is defined outside the `chowcho.run` and may track closed windows, for example by the following workflow.

1. run `chowcho.run`
2. close some windows
3. run `chowcho.run`

This may cause user-specified number to index the closed window from `_wins`.

This PR fixes the problem by defining `_wins` inside the `chowcho.run`