### PR TITLE
run should iterate over valid windows

### DIFF
--- a/lua/chowcho/init.lua
+++ b/lua/chowcho/init.lua
@@ -98,6 +98,7 @@ chowcho.run = function(fn, opt)
 
   local _wins = {}
   for i, v in ipairs(wins) do
+    if not vim.api.nvim_win_is_valid(v) then goto continue end
     local pos = calc_center_win_pos(v)
     local buf = vim.api.nvim_win_get_buf(v)
     local bt = vim.api.nvim_buf_get_option(buf, 'buftype')


### PR DESCRIPTION
There are some edge cases where window closes after `nvim_tabpage_list_wins` is done by `chowcho.run`.

I faced the issue with https://github.com/nvim-treesitter/nvim-treesitter-context .

This PR introduces `nvim_win_is_valid` to reduce such unexpected errors.

> E5108: Error executing lua: ....local/share/nvim/lazy/chowcho.nvim/lua/chowcho/init.lua:55: Invalid window id: 1015
> stack traceback:
> 	[C]: in function 'nvim_win_get_width'
> 	....local/share/nvim/lazy/chowcho.nvim/lua/chowcho/init.lua:55: in function 'calc_center_win_pos'
> 	....local/share/nvim/lazy/chowcho.nvim/lua/chowcho/init.lua:101: in function 'run'
> 	/home/atusy/.config/nvim/lua/config/window.lua:26: in function </home/atusy/.config/nvim/lua/config/window.lua:23>

