### PR TITLE
add zindex parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ require('chowcho').setup {
     -- Note that below is identical to the `use_exclude_default = true`.
     local fname = vim.fn.expand('#' .. buf .. ':t')
     return fname == ''
-  end
+  end,
+  zindex = 10000, -- sufficiently large value to show on top of the other windows
 }
 ```
 

--- a/lua/chowcho/init.lua
+++ b/lua/chowcho/init.lua
@@ -13,6 +13,7 @@ local _opt = {
   border_style = 'default',
   use_exclude_default = true,
   exclude = nil,
+  zindex = 10000,
 }
 
 local _border_style = {
@@ -120,7 +121,7 @@ chowcho.run = function(fn, opt)
       end
       local bufnr, f_win, win = ui.create_floating_win(pos.w, pos.h, v,
                                                        {str(i), fname},
-                                                       _border_style[opt_local.border_style])
+                                                       _border_style[opt_local.border_style],_opt.zindex)
 
       if is_enable_icon(opt_local) then
         local line = vim.api.nvim_buf_get_lines(bufnr, 1, 2, false)
@@ -180,6 +181,7 @@ chowcho.setup = function(opt)
     if opt.border_style ~= nil then _opt.border_style = opt.border_style end
     if opt.use_exclude_default ~= nil then _opt.use_exclude_default = opt.use_exclude_default end
     if opt.exclude ~= nil then _opt.exclude = opt.exclude end
+    if opt.zindex ~= nil then _opt.zindex = opt.zindex end
   else
     error('[chowcho.nvim] option is must be table')
   end

--- a/lua/chowcho/ui.lua
+++ b/lua/chowcho/ui.lua
@@ -29,7 +29,7 @@ local create_content = function(label, border_style)
   return {top, content, bottom}
 end
 
-ui.create_floating_win = function(x, y, win, label, border_style)
+ui.create_floating_win = function(x, y, win, label, border_style, zindex)
   local buf = vim.api.nvim_create_buf(false, true)
 
   local win_num = label[1]
@@ -48,7 +48,8 @@ ui.create_floating_win = function(x, y, win, label, border_style)
     row = y,
     anchor = 'NW',
     style = 'minimal',
-    focusable = false
+    focusable = false,
+    zindex = zindex,
   }
 
   local float_win = vim.api.nvim_open_win(buf, false, opt)


### PR DESCRIPTION
In some cases, window labels are hidden by the other floating windows.

This PR adds zindex parameter to setup function so that the problem occurs less.


